### PR TITLE
Fix TestBed target dependency naming

### DIFF
--- a/samples/Testbed/xcode/TestBed.xcodeproj/project.pbxproj
+++ b/samples/Testbed/xcode/TestBed.xcodeproj/project.pbxproj
@@ -36,18 +36,18 @@
 			remoteGlobalIDString = 9416178C1C05952400074DE9;
 			remoteInfo = "liquidfun-ios-sim";
 		};
+		941617A81C05AC0C00074DE9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9496D4E51C043EE000A54274 /* liquidfun.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 9496D3FE1C043B8F00A54274;
+			remoteInfo = "liquidfun-macosx";
+		};
 		9496D4E91C043EE000A54274 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9496D4E51C043EE000A54274 /* liquidfun.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 9496D3FF1C043B8F00A54274;
-			remoteInfo = liquidfun;
-		};
-		9496D4EC1C043F0600A54274 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9496D4E51C043EE000A54274 /* liquidfun.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 9496D3FE1C043B8F00A54274;
 			remoteInfo = liquidfun;
 		};
 		9496D59D1C045F4C00A54274 /* PBXContainerItemProxy */ = {
@@ -386,9 +386,9 @@
 		9496D4E61C043EE000A54274 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				9496D4EA1C043EE000A54274 /* libliquidfun-macosx_d.a */,
-				9496D59E1C045F4C00A54274 /* libliquidfun-ios_d.a */,
-				941617961C0597DD00074DE9 /* libliquidfun-ios-sim_d.a */,
+				9496D4EA1C043EE000A54274 /* libliquidfun_d.a */,
+				9496D59E1C045F4C00A54274 /* libliquidfun_d.a */,
+				941617961C0597DD00074DE9 /* libliquidfun_d.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -407,7 +407,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				9496D4ED1C043F0600A54274 /* PBXTargetDependency */,
+				941617A91C05AC0C00074DE9 /* PBXTargetDependency */,
 			);
 			name = TestBed;
 			productInstallPath = "$(HOME)/Applications";
@@ -448,24 +448,24 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		941617961C0597DD00074DE9 /* libliquidfun-ios-sim_d.a */ = {
+		941617961C0597DD00074DE9 /* libliquidfun_d.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libliquidfun-ios-sim_d.a";
+			path = libliquidfun_d.a;
 			remoteRef = 941617951C0597DD00074DE9 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		9496D4EA1C043EE000A54274 /* libliquidfun-macosx_d.a */ = {
+		9496D4EA1C043EE000A54274 /* libliquidfun_d.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libliquidfun-macosx_d.a";
+			path = libliquidfun_d.a;
 			remoteRef = 9496D4E91C043EE000A54274 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		9496D59E1C045F4C00A54274 /* libliquidfun-ios_d.a */ = {
+		9496D59E1C045F4C00A54274 /* libliquidfun_d.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libliquidfun-ios_d.a";
+			path = libliquidfun_d.a;
 			remoteRef = 9496D59D1C045F4C00A54274 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -500,10 +500,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		9496D4ED1C043F0600A54274 /* PBXTargetDependency */ = {
+		941617A91C05AC0C00074DE9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = liquidfun;
-			targetProxy = 9496D4EC1C043F0600A54274 /* PBXContainerItemProxy */;
+			name = "liquidfun-macosx";
+			targetProxy = 941617A81C05AC0C00074DE9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/samples/Testbed/xcode_ios/TestBed.xcodeproj/project.pbxproj
+++ b/samples/Testbed/xcode_ios/TestBed.xcodeproj/project.pbxproj
@@ -40,7 +40,14 @@
 			remoteGlobalIDString = 9416178C1C05952400074DE9;
 			remoteInfo = "liquidfun-ios-sim";
 		};
-		941617901C05972400074DE9 /* PBXContainerItemProxy */ = {
+		9416179E1C05AB0100074DE9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9496D54E1C044D0C00A54274 /* liquidfun.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 9496D5571C044E1800A54274;
+			remoteInfo = "liquidfun-ios";
+		};
+		941617A01C05AB0100074DE9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9496D54E1C044D0C00A54274 /* liquidfun.xcodeproj */;
 			proxyType = 1;
@@ -59,13 +66,6 @@
 			containerPortal = 9496D54E1C044D0C00A54274 /* liquidfun.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 9496D5941C044E1800A54274;
-			remoteInfo = liquidfun_ios;
-		};
-		9496D5991C044E8B00A54274 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9496D54E1C044D0C00A54274 /* liquidfun.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 9496D5571C044E1800A54274;
 			remoteInfo = liquidfun_ios;
 		};
 /* End PBXContainerItemProxy section */
@@ -373,7 +373,7 @@
 			children = (
 				9496D5531C044D0C00A54274 /* libliquidfun_d.a */,
 				9496D5971C044E7C00A54274 /* libliquidfun_d.a */,
-				9416178F1C0596D600074DE9 /* libliquidfun-ios-sim_d.a */,
+				9416178F1C0596D600074DE9 /* libliquidfun_d.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -409,8 +409,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				941617911C05972400074DE9 /* PBXTargetDependency */,
-				9496D59A1C044E8B00A54274 /* PBXTargetDependency */,
+				9416179F1C05AB0100074DE9 /* PBXTargetDependency */,
+				941617A11C05AB0100074DE9 /* PBXTargetDependency */,
 			);
 			name = TestBed;
 			productName = TestBed;
@@ -448,10 +448,10 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		9416178F1C0596D600074DE9 /* libliquidfun-ios-sim_d.a */ = {
+		9416178F1C0596D600074DE9 /* libliquidfun_d.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libliquidfun-ios-sim_d.a";
+			path = libliquidfun_d.a;
 			remoteRef = 9416178E1C0596D600074DE9 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -502,15 +502,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		941617911C05972400074DE9 /* PBXTargetDependency */ = {
+		9416179F1C05AB0100074DE9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "liquidfun-ios";
+			targetProxy = 9416179E1C05AB0100074DE9 /* PBXContainerItemProxy */;
+		};
+		941617A11C05AB0100074DE9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "liquidfun-ios-sim";
-			targetProxy = 941617901C05972400074DE9 /* PBXContainerItemProxy */;
-		};
-		9496D59A1C044E8B00A54274 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = liquidfun_ios;
-			targetProxy = 9496D5991C044E8B00A54274 /* PBXContainerItemProxy */;
+			targetProxy = 941617A01C05AB0100074DE9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
Some of the deps were named incorrectly. I'm not totally sure this matters for the actual build, but it should at least make the .xcodeproj more consistent if someone happens to look.
